### PR TITLE
Fix lesson prerequisite sorting bug

### DIFF
--- a/renderer/js/lessonGenerator.js
+++ b/renderer/js/lessonGenerator.js
@@ -86,16 +86,18 @@ const LessonGenerator = {
    * @returns {Array} - Sorted array of topics
    */
   sortTopicsBasedOnPrerequisites: function(topics, relationships) {
-    // Create a directed graph of prerequisites
+    // Create a directed graph where edges point from a prerequisite to the
+    // topic that depends on it. This orientation ensures that a topic appears
+    // after all of its prerequisites in the final ordering.
     const graph = {};
     topics.forEach(topic => {
       graph[topic.id] = [];
     });
-    
-    // Add prerequisite relationships to the graph
+
+    // Build adjacency lists based on prerequisite relationships
     relationships.forEach(rel => {
-      if (rel.type === 'prerequisite' && graph[rel.target]) {
-        graph[rel.target].push(rel.source);
+      if (rel.type === 'prerequisite' && graph[rel.source] !== undefined && graph[rel.target] !== undefined) {
+        graph[rel.source].push(rel.target);
       }
     });
     
@@ -109,10 +111,10 @@ const LessonGenerator = {
       inDegree[node] = 0;
     });
     
-    // Calculate in-degree for each node
+    // Calculate in-degree for each node based on incoming edges
     Object.keys(graph).forEach(node => {
-      graph[node].forEach(prerequisite => {
-        inDegree[prerequisite] = (inDegree[prerequisite] || 0) + 1;
+      graph[node].forEach(dependent => {
+        inDegree[dependent] = (inDegree[dependent] || 0) + 1;
       });
     });
     


### PR DESCRIPTION
## Summary
- fix orientation of edges in `sortTopicsBasedOnPrerequisites`

## Testing
- `npm test` *(fails: Error: no test specified)*

## Summary by Sourcery

Correct the orientation of edges in the prerequisite graph to ensure topics are sorted after their prerequisites

Bug Fixes:
- Fix edge direction in sortTopicsBasedOnPrerequisites to build adjacency from prerequisites to dependents
- Adjust in-degree calculation to reflect incoming edges from prerequisites correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the ordering of topics so that each topic now appears after all its prerequisites.

- **Documentation**
  - Improved comments to clarify how topics and prerequisites are processed and sorted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->