### PR TITLE
Add Jest setup and test for prerequisite sorting

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -16,5 +16,8 @@
     "multer": "^1.4.5-lts.2",
     "pdf-lib": "^1.17.1",
     "sqlite3": "^5.1.7"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/renderer/js/__tests__/lessonGenerator.test.js
+++ b/renderer/js/__tests__/lessonGenerator.test.js
@@ -1,0 +1,20 @@
+const LessonGenerator = require('../lessonGenerator');
+
+describe('sortTopicsBasedOnPrerequisites', () => {
+  test('orders topics based on prerequisite relationships', () => {
+    const topics = [
+      { id: 1, title: 'A', subtopics: [] },
+      { id: 2, title: 'B', subtopics: [] },
+      { id: 3, title: 'C', subtopics: [] }
+    ];
+
+    const relationships = [
+      { source: 1, target: 2, type: 'prerequisite' },
+      { source: 2, target: 3, type: 'prerequisite' }
+    ];
+
+    const result = LessonGenerator.sortTopicsBasedOnPrerequisites(topics, relationships);
+    const resultIds = result.map(t => t.id);
+    expect(resultIds).toEqual([1, 2, 3]);
+  });
+});

--- a/renderer/js/lessonGenerator.js
+++ b/renderer/js/lessonGenerator.js
@@ -86,59 +86,48 @@ const LessonGenerator = {
    * @returns {Array} - Sorted array of topics
    */
   sortTopicsBasedOnPrerequisites: function(topics, relationships) {
-    // Create a directed graph of prerequisites
+    // Build a graph where edges point from prerequisites to dependent topics
     const graph = {};
+    const inDegree = {};
+
+    // Initialize graph and indegree map
     topics.forEach(topic => {
       graph[topic.id] = [];
+      inDegree[topic.id] = 0;
     });
-    
-    // Add prerequisite relationships to the graph
+
+    // Populate edges and compute in-degree for targets
     relationships.forEach(rel => {
-      if (rel.type === 'prerequisite' && graph[rel.target]) {
-        graph[rel.target].push(rel.source);
+      if (
+        rel.type === 'prerequisite' &&
+        graph.hasOwnProperty(rel.source) &&
+        graph.hasOwnProperty(rel.target)
+      ) {
+        graph[rel.source].push(rel.target);
+        inDegree[rel.target]++;
       }
     });
-    
-    // Topological sort (Kahn's algorithm)
+
+    // Kahn's algorithm for topological sorting
+    const queue = Object.keys(inDegree).filter(id => inDegree[id] === 0);
     const result = [];
-    const inDegree = {};
-    const queue = [];
-    
-    // Initialize in-degree for all nodes
-    Object.keys(graph).forEach(node => {
-      inDegree[node] = 0;
-    });
-    
-    // Calculate in-degree for each node
-    Object.keys(graph).forEach(node => {
-      graph[node].forEach(prerequisite => {
-        inDegree[prerequisite] = (inDegree[prerequisite] || 0) + 1;
-      });
-    });
-    
-    // Add nodes with in-degree 0 to the queue
-    Object.keys(inDegree).forEach(node => {
-      if (inDegree[node] === 0) {
-        queue.push(node);
-      }
-    });
-    
-    // Process the queue
+
     while (queue.length > 0) {
       const node = queue.shift();
       result.push(node);
-      
-      // Reduce in-degree of adjacent nodes
-      graph[node].forEach(adjacentNode => {
-        inDegree[adjacentNode]--;
-        if (inDegree[adjacentNode] === 0) {
-          queue.push(adjacentNode);
+
+      graph[node].forEach(next => {
+        inDegree[next]--;
+        if (inDegree[next] === 0) {
+          queue.push(next);
         }
       });
     }
-    
-    // Map the sorted node IDs back to the original topics
-    return result.map(id => topics.find(topic => topic.id.toString() === id.toString())).filter(Boolean);
+
+    // Map sorted IDs back to topic objects
+    return result
+      .map(id => topics.find(topic => topic.id.toString() === id.toString()))
+      .filter(Boolean);
   },
   
   /**
@@ -518,3 +507,10 @@ const LessonGenerator = {
     }
   }
 };
+
+// Export for Node.js environments while preserving browser usage
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = LessonGenerator;
+} else {
+  window.LessonGenerator = LessonGenerator;
+}


### PR DESCRIPTION
## Summary
- add Jest to devDependencies and configure npm test script
- export `LessonGenerator` for Node environments
- implement topological sort for prerequisites
- add unit test for `sortTopicsBasedOnPrerequisites`

## Testing
- `npm test` *(fails: jest not found)*

## Summary by Sourcery

Set up Jest for testing, implement topological sorting for topic prerequisites, and support Node exports

Enhancements:
- Implement topological sort algorithm for sorting topics based on prerequisites
- Export LessonGenerator for Node.js and browser environments

Build:
- Add Jest as a dev dependency and configure the npm test script

Tests:
- Add a Jest unit test for the sortTopicsBasedOnPrerequisites function