### PR TITLE
Fix prerequisite sorting

### DIFF
--- a/renderer/js/lessonGenerator.js
+++ b/renderer/js/lessonGenerator.js
@@ -86,16 +86,16 @@ const LessonGenerator = {
    * @returns {Array} - Sorted array of topics
    */
   sortTopicsBasedOnPrerequisites: function(topics, relationships) {
-    // Create a directed graph of prerequisites
+    // Create a directed graph where each prerequisite points to its dependents
     const graph = {};
     topics.forEach(topic => {
       graph[topic.id] = [];
     });
-    
-    // Add prerequisite relationships to the graph
+
+    // Add edges from prerequisite (source) to dependent (target)
     relationships.forEach(rel => {
-      if (rel.type === 'prerequisite' && graph[rel.target]) {
-        graph[rel.target].push(rel.source);
+      if (rel.type === 'prerequisite' && graph[rel.source] && graph[rel.target]) {
+        graph[rel.source].push(rel.target);
       }
     });
     
@@ -109,10 +109,10 @@ const LessonGenerator = {
       inDegree[node] = 0;
     });
     
-    // Calculate in-degree for each node
+    // Calculate in-degree for each node based on incoming edges
     Object.keys(graph).forEach(node => {
-      graph[node].forEach(prerequisite => {
-        inDegree[prerequisite] = (inDegree[prerequisite] || 0) + 1;
+      graph[node].forEach(dependent => {
+        inDegree[dependent] = (inDegree[dependent] || 0) + 1;
       });
     });
     


### PR DESCRIPTION
## Summary
- correct prerequisite graph structure in lesson generator
- compute in-degree from incoming edges to ensure topological ordering

## Testing
- `npm test` *(fails: no test specified)*

## Summary by Sourcery

Fix topic sorting by prerequisites by reversing graph edges and computing in-degrees based on incoming edges

Bug Fixes:
- Reverse the prerequisite graph to map each topic to its dependents for correct topological ordering
- Compute in-degree counts from incoming edges instead of outgoing edges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the ordering of topics to accurately respect prerequisite relationships, ensuring topics are now presented in the correct sequence based on their dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->