### PR TITLE
Add build scripts and expand tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.0",
   "main": "main.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest --coverage",
+    "build:mac": "electron-builder --mac",
+    "build:windows": "electron-builder --win",
+    "build:ios": "echo 'iOS build not supported yet'",
+    "build:android": "echo 'Android build not supported yet'"
   },
   "keywords": [],
   "author": "",
@@ -18,6 +22,7 @@
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "electron-builder": "^24.6.0"
   }
 }

--- a/renderer/js/__tests__/lessonGenerator.test.js
+++ b/renderer/js/__tests__/lessonGenerator.test.js
@@ -1,5 +1,6 @@
 const LessonGenerator = require('../lessonGenerator');
 
+// Tests for sortTopicsBasedOnPrerequisites
 describe('sortTopicsBasedOnPrerequisites', () => {
   test('orders topics based on prerequisite relationships', () => {
     const topics = [
@@ -7,14 +8,106 @@ describe('sortTopicsBasedOnPrerequisites', () => {
       { id: 2, title: 'B', subtopics: [] },
       { id: 3, title: 'C', subtopics: [] }
     ];
-
     const relationships = [
       { source: 1, target: 2, type: 'prerequisite' },
       { source: 2, target: 3, type: 'prerequisite' }
     ];
-
     const result = LessonGenerator.sortTopicsBasedOnPrerequisites(topics, relationships);
     const resultIds = result.map(t => t.id);
     expect(resultIds).toEqual([1, 2, 3]);
   });
 });
+
+// Tests for generateOverview
+describe('generateOverview', () => {
+  test('uses first sentences when available', () => {
+    const topic = { title: 'Topic', content: 'One. Two. Three. Four.' };
+    const overview = LessonGenerator.generateOverview(topic);
+    expect(overview).toBe('One. Two. Three.');
+  });
+
+  test('falls back to generic overview', () => {
+    const topic = { title: 'Topic' };
+    const overview = LessonGenerator.generateOverview(topic);
+    expect(overview).toContain('This lesson covers Topic');
+  });
+});
+
+// Tests for generateLearningObjectives
+describe('generateLearningObjectives', () => {
+  test('creates a set of objectives', () => {
+    const topic = { title: 'Algebra', content: '**term** is defined as something', level: 2 };
+    const objs = LessonGenerator.generateLearningObjectives(topic);
+    expect(Array.isArray(objs)).toBe(true);
+    expect(objs.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// Tests for generateSections
+describe('generateSections', () => {
+  test('creates sections from subtopics with intro and summary', () => {
+    const topic = { title: 'Main', content: 'Intro', subtopics: [{ title: 'Sub', content: 'subtext' }] };
+    const sections = LessonGenerator.generateSections(topic);
+    expect(sections[0].title).toBe('Introduction');
+    expect(sections[sections.length - 1].title).toBe('Summary');
+  });
+});
+
+// Tests for generatePracticeProblems
+describe('generatePracticeProblems', () => {
+  test('creates placeholder problems', () => {
+    const problems = LessonGenerator.generatePracticeProblems({ id: 1, title: 'Calc' });
+    expect(problems.length).toBe(3);
+    expect(problems[0].question).toContain('Calc');
+  });
+});
+
+// Tests for generateAssessment
+describe('generateAssessment', () => {
+  test('creates an assessment structure', () => {
+    const assessment = LessonGenerator.generateAssessment({ id: 1, title: 'Topic' });
+    expect(assessment.questions.length).toBe(3);
+    expect(assessment.passingScore).toBeGreaterThan(0);
+  });
+});
+
+// Tests for generateFurtherResources
+describe('generateFurtherResources', () => {
+  test('adds concept definitions and additional reading', () => {
+    const topic = { title: 'Topic', content: 'contains concept' };
+    const concepts = [{ term: 'concept', definition: 'def' }];
+    const resources = LessonGenerator.generateFurtherResources(topic, concepts);
+    expect(resources.some(r => r.type === 'definition')).toBe(true);
+    expect(resources.some(r => r.title === 'Additional Reading')).toBe(true);
+  });
+});
+
+// Tests for identifyApplicablePrinciples and related helpers
+describe('principles utilities', () => {
+  test('identifyApplicablePrinciples adds defaults', () => {
+    const principles = [{ name: 'Working Memory' }];
+    const result = LessonGenerator.identifyApplicablePrinciples(principles);
+    const names = result.map(p => p.name);
+    expect(names).toContain('Working Memory');
+    expect(names).toContain('Knowledge Graph');
+    expect(names).toContain('Scaffolded Mastery Learning');
+  });
+
+  test('getPrincipleImplementation returns known text', () => {
+    const text = LessonGenerator.getPrincipleImplementation('Working Memory');
+    expect(text).toContain('working memory');
+  });
+
+  test('applyMathAcademyPrinciples generates applications', () => {
+    const topic = { title: 'Topic' };
+    const principles = [{ name: 'Working Memory', description: 'd' }];
+    const result = LessonGenerator.applyMathAcademyPrinciples(topic, principles);
+    expect(result[0].application).toContain('Break Topic');
+  });
+
+  test('generatePrincipleApplication handles default', () => {
+    const text = LessonGenerator.generatePrincipleApplication('Unknown', { title: 'Topic' });
+    expect(text).toContain('Unknown');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add build scripts for mac, windows, ios and android
- add electron-builder to dev deps
- expand lesson generator unit tests and enable coverage

## Testing
- `npm test` *(fails: jest not found)*

## Summary by Sourcery

Introduce cross-platform build commands, include electron-builder, enable Jest coverage, and broaden unit test coverage for lesson generation utilities

Enhancements:
- Add electron-builder to devDependencies for packaging capabilities

Build:
- Add npm build scripts for mac, windows, ios, and android
- Update test script to run Jest with coverage reporting

Tests:
- Expand LessonGenerator unit tests to cover sorting, overview generation, learning objectives, sections, practice problems, assessment, further resources, and principles utilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added build scripts for macOS and Windows, enabling platform-specific builds.
  - Introduced placeholder scripts for iOS and Android builds, indicating these platforms are not yet supported.

- **Chores**
  - Added coverage reporting to test scripts.
  - Included a new development dependency for building desktop applications.

- **Tests**
  - Expanded test coverage for lesson generation features, including comprehensive tests for content generation, learning objectives, sections, practice problems, assessments, further resources, and educational principles integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->